### PR TITLE
Add TPESampler State Persistence for Distributed Optimization

### DIFF
--- a/config/training/training_inputs_juan_awaken_tune_storm_pred510.yaml
+++ b/config/training/training_inputs_juan_awaken_tune_storm_pred510.yaml
@@ -39,8 +39,8 @@ optuna:
   pruning:
     enabled: true
     type: "patient"
-    patience: 2               # Configure PatientPruner: number of steps to wait (epochs) before pruning
-    min_delta: 1.0            # Configure PatientPruner: tolerance for improvement (default 0.0)
+    patience: 1               # Configure PatientPruner: number of steps to wait (epochs) before pruning
+    min_delta: 2.0            # Configure PatientPruner: tolerance for improvement (default 0.0)
     wrapped_pruner:
       type: "percentile"      # Set the wrapped pruner type
       percentile: 50.0        # Configure PercentilePruner: prune trials below this percentile

--- a/wind_forecasting/run_scripts/tune_scripts/tune_model_storm_awaken_p210.sh
+++ b/wind_forecasting/run_scripts/tune_scripts/tune_model_storm_awaken_p210.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-#SBATCH --partition=cfdg.p          # Partition for H100/A100 GPUs cfdg.p / all_gpu.p / mpcg.p(not allowed)
+#SBATCH --partition=all_gpu.p          # Partition for H100/A100 GPUs cfdg.p / all_gpu.p / mpcg.p(not allowed)
 #SBATCH --nodes=1
-#SBATCH --ntasks-per-node=4         # Match number of GPUs requested below
-#SBATCH --cpus-per-task=32           # CPUs per task (4 tasks * 32 = 128 CPUs total) [1 CPU/GPU more than enough]
-#SBATCH --mem-per-cpu=8192           # Memory per CPU (Total Mem = ntasks * cpus-per-task * mem-per-cpu) [flasc uses only ~4-5 GiB max]
-#SBATCH --gres=gpu:4            # Request 2 H100 GPUs
+#SBATCH --ntasks-per-node=1         # Match number of GPUs requested below
+#SBATCH --cpus-per-task=8           # CPUs per task (4 tasks * 32 = 128 CPUs total) [1 CPU/GPU more than enough]
+#SBATCH --mem-per-cpu=8016           # Memory per CPU (Total Mem = ntasks * cpus-per-task * mem-per-cpu) [flasc uses only ~4-5 GiB max]
+#SBATCH --gres=gpu:1            # Request 2 H100 GPUs
 #SBATCH --time=1-00:00                # Time limit (up to 1 day)
 #SBATCH --job-name=210awaken_tune_tactis
 #SBATCH --output=/dss/work/taed7566/Forecasting_Outputs/wind-forecasting/logs/slurm_logs/awaken_tune_tactis210_%j.out

--- a/wind_forecasting/run_scripts/tune_scripts/tune_model_storm_awaken_p510.sh
+++ b/wind_forecasting/run_scripts/tune_scripts/tune_model_storm_awaken_p510.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-#SBATCH --partition=cfdg.p          # Partition for H100/A100 GPUs cfdg.p / all_gpu.p / mpcg.p(not allowed)
+#SBATCH --partition=all_gpu.p          # Partition for H100/A100 GPUs cfdg.p / all_gpu.p / mpcg.p(not allowed)
 #SBATCH --nodes=1
-#SBATCH --ntasks-per-node=4         # Match number of GPUs requested below
-#SBATCH --cpus-per-task=32           # CPUs per task (4 tasks * 32 = 128 CPUs total) [1 CPU/GPU more than enough]
-#SBATCH --mem-per-cpu=8192           # Memory per CPU (Total Mem = ntasks * cpus-per-task * mem-per-cpu) [flasc uses only ~4-5 GiB max]
-#SBATCH --gres=gpu:4            # Request 2 H100 GPUs
+#SBATCH --ntasks-per-node=1         # Match number of GPUs requested below
+#SBATCH --cpus-per-task=8           # CPUs per task (4 tasks * 32 = 128 CPUs total) [1 CPU/GPU more than enough]
+#SBATCH --mem-per-cpu=8016           # Memory per CPU (Total Mem = ntasks * cpus-per-task * mem-per-cpu) [flasc uses only ~4-5 GiB max]
+#SBATCH --gres=gpu:1            # Request 2 H100 GPUs
 #SBATCH --time=1-00:00                # Time limit (up to 7 days)
 #SBATCH --job-name=510awaken_tune_tactis
 #SBATCH --output=/dss/work/taed7566/Forecasting_Outputs/wind-forecasting/logs/slurm_logs/awaken_tune_tactis510_%j.out

--- a/wind_forecasting/utils/optuna_sampler_pruner_utils.py
+++ b/wind_forecasting/utils/optuna_sampler_pruner_utils.py
@@ -80,9 +80,67 @@ class OptunaSamplerPrunerPersistence:
         logging.info(f"Loaded sampler and pruner from {sampler_path} and {pruner_path}")
         return sampler, pruner
 
+    def _load_sampler_pruner_partial(self, sampler_path, pruner_path, fallback_pruner):
+        """
+        Load sampler and pruner from pickle files, supporting partial loading.
+        If one pickle is missing, use fallback for that component.
+        
+        Args:
+            sampler_path: Path to sampler pickle file
+            pruner_path: Path to pruner pickle file
+            fallback_pruner: Pruner instance to use if pruner pickle is missing
+            
+        Returns:
+            tuple: (sampler, pruner)
+        """
+        sampler = None
+        pruner = None
+        
+        # Try to load sampler
+        if os.path.exists(sampler_path):
+            try:
+                with open(sampler_path, 'rb') as f:
+                    sampler = pickle.load(f)
+                logging.info(f"Successfully loaded existing sampler from {sampler_path}")
+            except Exception as e:
+                logging.warning(f"Failed to load sampler from {sampler_path}: {e}")
+                sampler = None
+        else:
+            logging.info(f"Sampler pickle file not found: {sampler_path}")
+        
+        # Try to load pruner
+        if os.path.exists(pruner_path):
+            try:
+                with open(pruner_path, 'rb') as f:
+                    pruner = pickle.load(f)
+                logging.info(f"Successfully loaded existing pruner from {pruner_path}")
+            except Exception as e:
+                logging.warning(f"Failed to load pruner from {pruner_path}: {e}")
+                pruner = None
+        else:
+            logging.info(f"Pruner pickle file not found: {pruner_path}")
+        
+        # Create fallbacks for missing components
+        if sampler is None:
+            logging.info("Creating new sampler with current configuration")
+            sampler = TPESampler(
+                seed=self.seed,
+                n_startup_trials=self.config["optuna"]["sampler_params"]["tpe"].get("n_startup_trials", 16),
+                multivariate=self.config["optuna"]["sampler_params"]["tpe"].get("multivariate", True),
+                constant_liar=self.config["optuna"]["sampler_params"]["tpe"].get("constant_liar", True),
+                group=self.config["optuna"]["sampler_params"]["tpe"].get("group", False)
+            )
+        
+        if pruner is None:
+            logging.info("Using fallback pruner from current configuration")
+            pruner = fallback_pruner
+        
+        return sampler, pruner
+
     def _wait_and_load_sampler_pruner(self, sampler_path, pruner_path, max_wait=300):
         """
         Wait for pickle files to exist and then load sampler and pruner.
+        Will wait for both files initially, but will accept partial files after half the wait time.
         
         Args:
             sampler_path: Path to sampler pickle file
@@ -97,25 +155,47 @@ class OptunaSamplerPrunerPersistence:
         """
         wait_interval = 5  # seconds
         elapsed = 0
+        partial_wait_threshold = max_wait // 2  # Try partial loading after half the wait time
         
         while elapsed < max_wait:
-            if os.path.exists(sampler_path) and os.path.exists(pruner_path):
+            both_exist = os.path.exists(sampler_path) and os.path.exists(pruner_path)
+            either_exists = os.path.exists(sampler_path) or os.path.exists(pruner_path)
+            
+            # If both files exist, try normal loading
+            if both_exist:
                 try:
                     return self._load_sampler_pruner(sampler_path, pruner_path)
                 except Exception as e:
-                    logging.warning(f"Failed to load pickle files (attempt after {elapsed}s): {e}")
+                    logging.warning(f"Failed to load both pickle files (attempt after {elapsed}s): {e}")
                     time.sleep(wait_interval)
                     elapsed += wait_interval
                     continue
-            else:
-                missing = []
-                if not os.path.exists(sampler_path):
-                    missing.append("sampler")
-                if not os.path.exists(pruner_path):
-                    missing.append("pruner")
+            
+            # After half the wait time, accept partial files if worker 0 has created at least one
+            elif either_exists and elapsed >= partial_wait_threshold:
+                logging.info(f"Worker waiting: Attempting to load partial pickle files after {elapsed}s")
+                try:
+                    # For non-worker-0, we don't have access to the fallback pruner config, 
+                    # so we'll raise an exception that tells them to wait longer
+                    return self._load_sampler_pruner(sampler_path, pruner_path)
+                except Exception as e:
+                    logging.warning(f"Partial loading failed for non-worker-0: {e}")
+                    logging.info("Non-worker-0 cannot perform partial loading - continuing to wait for both files")
+            
+            # Still waiting
+            missing = []
+            if not os.path.exists(sampler_path):
+                missing.append("sampler")
+            if not os.path.exists(pruner_path):
+                missing.append("pruner")
+            
+            if elapsed < partial_wait_threshold:
                 logging.info(f"Waiting for {', '.join(missing)} pickle file(s) to appear... ({elapsed}/{max_wait}s)")
-                time.sleep(wait_interval)
-                elapsed += wait_interval
+            else:
+                logging.info(f"Waiting for {', '.join(missing)} pickle file(s) (partial loading not available for non-worker-0)... ({elapsed}/{max_wait}s)")
+            
+            time.sleep(wait_interval)
+            elapsed += wait_interval
         
         raise TimeoutError(f"Sampler/pruner pickle files did not appear within {max_wait} seconds")
 
@@ -157,11 +237,28 @@ class OptunaSamplerPrunerPersistence:
             else:
                 # Scenario 2 (Continuing Existing Study - restart_tuning=False and study exists)
                 logging.info(f"Worker 0: Attempting to load existing sampler/pruner for study '{final_study_name}'")
+                
+                # First try the traditional approach (both files must exist)
+                if os.path.exists(sampler_path) and os.path.exists(pruner_path):
+                    try:
+                        return self._load_sampler_pruner(sampler_path, pruner_path)
+                    except Exception as e:
+                        logging.warning(f"Worker 0: Failed to load both sampler/pruner from pickle files: {e}")
+                        logging.info("Worker 0: Attempting partial loading...")
+                
+                # Try partial loading (handles missing or corrupted files)
                 try:
-                    return self._load_sampler_pruner(sampler_path, pruner_path)
+                    sampler, pruner_to_save = self._load_sampler_pruner_partial(sampler_path, pruner_path, pruner)
+                    
+                    # Save both components to ensure consistency for future workers
+                    # This handles cases where one was missing or corrupted
+                    logging.info("Worker 0: Saving updated sampler/pruner to ensure consistency")
+                    self._save_sampler_pruner_atomic(sampler, pruner_to_save, sampler_path, pruner_path)
+                    return sampler, pruner_to_save
+                    
                 except Exception as e:
-                    logging.warning(f"Worker 0: Failed to load sampler/pruner from pickle files: {e}")
-                    logging.info("Worker 0: Falling back to creating new sampler/pruner and saving them")
+                    logging.warning(f"Worker 0: Partial loading also failed: {e}")
+                    logging.info("Worker 0: Falling back to creating completely new sampler/pruner")
                     sampler, pruner_to_save = self._create_new_sampler_pruner(pruner)
                     self._save_sampler_pruner_atomic(sampler, pruner_to_save, sampler_path, pruner_path)
                     return sampler, pruner_to_save


### PR DESCRIPTION
# Add TPESampler State Persistence for Distributed Optimization

## Problem
When workers crash or restart in distributed Optuna optimization, TPESampler loses its accumulated state (search space cache, learned parameter groupings), causing redundant exploration and reduced efficiency.

## Solution
Save TPESampler/pruner state to pickle files after every trial completion, enabling crashed workers to resume with full algorithmic state.

## Changes

### 1. `wind_forecasting/utils/optuna_sampler_pruner_utils.py`
- Added partial loading/recreation of pickles in case just one missing (change pruner for example)
- Added `create_trial_completion_callback()` method to save state after trials
- Each worker saves its own state (not just worker 0)
- Atomic file operations prevent corruption

### 2. `wind_forecasting/run_scripts/tuning.py`
- Added callback to save sampler state after every trial
- 7 lines of code added to existing workflow

```python
sampler_checkpoint_callback = sampler_pruner_persistence.create_trial_completion_callback(
    worker_id=worker_id,
    save_frequency=1  # Every trial
)
optimize_callbacks.append(sampler_checkpoint_callback)
```

## Benefits
- **Crash recovery**: Workers resume with latest optimization state
- **Dynamic scaling**: Add new workers anytime without losing progress
- **No performance impact**: Pickle I/O is negligible vs trial duration

## Testing
Verified: concurrent workers, crash recovery, new workers joining mid-optimization all work correctly.